### PR TITLE
fix: fixing core request

### DIFF
--- a/lib/ScheduleManager.js
+++ b/lib/ScheduleManager.js
@@ -16,7 +16,12 @@ class ScheduleManager {
     }
 
     getSchedules() {
-        return fetch(`${this.config.oppCoreApiUrl}/schedules`);
+        return fetch(
+            `${this.config.oopCoreApiUrl}/schedules`,
+            {
+                headers: { "X-Core-Token": this.config.oopCoreToken }
+            }
+        ).then(res => res.json());
     }
 
     setupSchedules(schedules) {
@@ -46,7 +51,7 @@ class ScheduleManager {
             }
         }
 
-        for (const scheduleId in this.schedules) {
+        for (const scheduleId of Object.keys(this.schedules)) {
             if (!seenIds.includes(String(scheduleId))) {
                 const loaded = this.schedules[scheduleId];
 


### PR DESCRIPTION
The request to get schedules from core didn't include the correct auth header.